### PR TITLE
Web component adjustments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,8 @@
                 "process": "^0.11.10",
                 "regenerator-runtime": "^0.13.11",
                 "sass": "^1.57.1",
+                "unplugin-auto-import": "^0.13.0",
+                "unplugin-vue-components": "^0.23.0",
                 "vite": "^4.1.1"
             }
         },
@@ -68,6 +70,15 @@
                 "node": ">=6.0.0"
             }
         },
+        "node_modules/@antfu/utils": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-0.7.2.tgz",
+            "integrity": "sha512-vy9fM3pIxZmX07dL+VX1aZe7ynZ+YyB0jY+jE6r3hOK6GNY2t6W8rzpFC4tgpbXUYABkFQwgJq2XYXlxbXAI0g==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
         "node_modules/@babel/code-frame": {
             "version": "7.18.6",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
@@ -81,34 +92,34 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.20.1",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.1.tgz",
-            "integrity": "sha512-EWZ4mE2diW3QALKvDMiXnbZpRvlj+nayZ112nK93SnhqOtpdsbVD4W+2tEoT3YNBAG9RBR0ISY758ZkOgsn6pQ==",
+            "version": "7.20.14",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.14.tgz",
+            "integrity": "sha512-0YpKHD6ImkWMEINCyDAD0HLLUH/lPCefG8ld9it8DJB2wnApraKuhgYTvTY1z7UFIfBTGy5LwncZ+5HWWGbhFw==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.19.1",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.1.tgz",
-            "integrity": "sha512-1H8VgqXme4UXCRv7/Wa1bq7RVymKOzC7znjyFM8KiEzwFqcKUKYNoQef4GhdklgNvoBXyW4gYhuBNCM5o1zImw==",
+            "version": "7.20.12",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz",
+            "integrity": "sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==",
             "dev": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.1.0",
                 "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.19.0",
-                "@babel/helper-compilation-targets": "^7.19.1",
-                "@babel/helper-module-transforms": "^7.19.0",
-                "@babel/helpers": "^7.19.0",
-                "@babel/parser": "^7.19.1",
-                "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.19.1",
-                "@babel/types": "^7.19.0",
+                "@babel/generator": "^7.20.7",
+                "@babel/helper-compilation-targets": "^7.20.7",
+                "@babel/helper-module-transforms": "^7.20.11",
+                "@babel/helpers": "^7.20.7",
+                "@babel/parser": "^7.20.7",
+                "@babel/template": "^7.20.7",
+                "@babel/traverse": "^7.20.12",
+                "@babel/types": "^7.20.7",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
-                "json5": "^2.2.1",
+                "json5": "^2.2.2",
                 "semver": "^6.3.0"
             },
             "engines": {
@@ -119,36 +130,13 @@
                 "url": "https://opencollective.com/babel"
             }
         },
-        "node_modules/@babel/core/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@babel/core/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
-        },
         "node_modules/@babel/generator": {
-            "version": "7.20.4",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.4.tgz",
-            "integrity": "sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==",
+            "version": "7.20.14",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.14.tgz",
+            "integrity": "sha512-AEmuXHdcD3A52HHXxaTmYlb8q/xMEhoRP67B3T4Oq7lbmSoqroMZzjnGj3+i1io3pdnF8iBYVu4Ilj+c4hBxYg==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.20.2",
+                "@babel/types": "^7.20.7",
                 "@jridgewell/gen-mapping": "^0.3.2",
                 "jsesc": "^2.5.1"
             },
@@ -157,14 +145,15 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.20.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.0.tgz",
-            "integrity": "sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==",
+            "version": "7.20.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
+            "integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
             "dev": true,
             "dependencies": {
-                "@babel/compat-data": "^7.20.0",
+                "@babel/compat-data": "^7.20.5",
                 "@babel/helper-validator-option": "^7.18.6",
                 "browserslist": "^4.21.3",
+                "lru-cache": "^5.1.1",
                 "semver": "^6.3.0"
             },
             "engines": {
@@ -173,6 +162,21 @@
             "peerDependencies": {
                 "@babel/core": "^7.0.0"
             }
+        },
+        "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+            "dev": true,
+            "dependencies": {
+                "yallist": "^3.0.2"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+            "dev": true
         },
         "node_modules/@babel/helper-environment-visitor": {
             "version": "7.18.9",
@@ -221,9 +225,9 @@
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.20.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.2.tgz",
-            "integrity": "sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==",
+            "version": "7.20.11",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz",
+            "integrity": "sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-environment-visitor": "^7.18.9",
@@ -231,9 +235,9 @@
                 "@babel/helper-simple-access": "^7.20.2",
                 "@babel/helper-split-export-declaration": "^7.18.6",
                 "@babel/helper-validator-identifier": "^7.19.1",
-                "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.20.1",
-                "@babel/types": "^7.20.2"
+                "@babel/template": "^7.20.7",
+                "@babel/traverse": "^7.20.10",
+                "@babel/types": "^7.20.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -300,14 +304,14 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.19.0.tgz",
-            "integrity": "sha512-DRBCKGwIEdqY3+rPJgG/dKfQy9+08rHIAJx8q2p+HSWP87s2HCrQmaAMMyMll2kIXKCW0cO1RdQskx15Xakftg==",
+            "version": "7.20.13",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.13.tgz",
+            "integrity": "sha512-nzJ0DWCL3gB5RCXbUO3KIMMsBY2Eqbx8mBpKGE/02PgyRQFcPQLbkQ1vyy596mZLaP+dAfD+R4ckASzNVmW3jg==",
             "dev": true,
             "dependencies": {
-                "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.19.0",
-                "@babel/types": "^7.19.0"
+                "@babel/template": "^7.20.7",
+                "@babel/traverse": "^7.20.13",
+                "@babel/types": "^7.20.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -390,9 +394,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.20.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.3.tgz",
-            "integrity": "sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==",
+            "version": "7.20.15",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.15.tgz",
+            "integrity": "sha512-DI4a1oZuf8wC+oAJA9RW6ga3Zbe8RZFt7kD9i4qAspz3I/yHet1VvC3DiSy/fsUvv5pvJuNPh0LPOdCcqinDPg==",
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -577,34 +581,43 @@
                 "@babel/core": "^7.0.0-0"
             }
         },
+        "node_modules/@babel/standalone": {
+            "version": "7.20.15",
+            "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.20.15.tgz",
+            "integrity": "sha512-B3LmZ1NHlTb2eFEaw8rftZc730Wh9MlmsH8ubb6IjsNoIk9+SQ2aAA0nrm/1806+PftPRAACPClmKTu8PG7Tew==",
+            "dev": true,
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/template": {
-            "version": "7.18.10",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
-            "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
+            "version": "7.20.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
+            "integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
             "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.18.6",
-                "@babel/parser": "^7.18.10",
-                "@babel/types": "^7.18.10"
+                "@babel/parser": "^7.20.7",
+                "@babel/types": "^7.20.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.20.1",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.1.tgz",
-            "integrity": "sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==",
+            "version": "7.20.13",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.13.tgz",
+            "integrity": "sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==",
             "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.20.1",
+                "@babel/generator": "^7.20.7",
                 "@babel/helper-environment-visitor": "^7.18.9",
                 "@babel/helper-function-name": "^7.19.0",
                 "@babel/helper-hoist-variables": "^7.18.6",
                 "@babel/helper-split-export-declaration": "^7.18.6",
-                "@babel/parser": "^7.20.1",
-                "@babel/types": "^7.20.0",
+                "@babel/parser": "^7.20.13",
+                "@babel/types": "^7.20.7",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             },
@@ -612,33 +625,10 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/traverse/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@babel/traverse/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
-        },
         "node_modules/@babel/types": {
-            "version": "7.20.2",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.2.tgz",
-            "integrity": "sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==",
+            "version": "7.20.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.7.tgz",
+            "integrity": "sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-string-parser": "^7.19.4",
@@ -793,27 +783,6 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
             "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
         },
-        "node_modules/@coedl/elastic-query-builder/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@coedl/elastic-query-builder/node_modules/debug/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
         "node_modules/@coedl/elastic-query-builder/node_modules/hpagent": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-0.1.2.tgz",
@@ -873,27 +842,6 @@
             "engines": {
                 "node": ">=14"
             }
-        },
-        "node_modules/@elastic/transport/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@elastic/transport/node_modules/debug/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node_modules/@elastic/transport/node_modules/ms": {
             "version": "2.1.3",
@@ -1823,6 +1771,74 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/@nuxt/kit": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.1.2.tgz",
+            "integrity": "sha512-m8/AF8hBJiG7aTx2CpiDGeLYYz30fUoPbJ9XiSmHqRIXv1goAFWHSkzWfRNEsoAAbMHf76oB917wVUQ3VSSQHg==",
+            "dev": true,
+            "dependencies": {
+                "@nuxt/schema": "3.1.2",
+                "c12": "^1.1.0",
+                "consola": "^2.15.3",
+                "defu": "^6.1.2",
+                "globby": "^13.1.3",
+                "hash-sum": "^2.0.0",
+                "ignore": "^5.2.4",
+                "jiti": "^1.16.2",
+                "knitwork": "^1.0.0",
+                "lodash.template": "^4.5.0",
+                "mlly": "^1.1.0",
+                "pathe": "^1.1.0",
+                "pkg-types": "^1.0.1",
+                "scule": "^1.0.0",
+                "semver": "^7.3.8",
+                "unctx": "^2.1.1",
+                "unimport": "^2.1.0",
+                "untyped": "^1.2.2"
+            },
+            "engines": {
+                "node": "^14.16.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@nuxt/kit/node_modules/semver": {
+            "version": "7.3.8",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@nuxt/schema": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.1.2.tgz",
+            "integrity": "sha512-wru9LhRXTa6WQlx7c0oYrtvJY7TiVlkBKXY5Rsmfo0StJuWohgZiReu9fu6z6GU4MzZlX25TVjwvq9Q7bNVbSQ==",
+            "dev": true,
+            "dependencies": {
+                "c12": "^1.1.0",
+                "create-require": "^1.1.1",
+                "defu": "^6.1.2",
+                "hookable": "^5.4.2",
+                "jiti": "^1.16.2",
+                "pathe": "^1.1.0",
+                "pkg-types": "^1.0.1",
+                "postcss-import-resolver": "^2.0.0",
+                "scule": "^1.0.0",
+                "std-env": "^3.3.2",
+                "ufo": "^1.0.1",
+                "unimport": "^2.1.0",
+                "untyped": "^1.2.2"
+            },
+            "engines": {
+                "node": "^14.16.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
         "node_modules/@popperjs/core": {
             "name": "@sxzz/popperjs-es",
             "version": "2.11.7",
@@ -1831,6 +1847,28 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
+            }
+        },
+        "node_modules/@rollup/pluginutils": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
+            "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+            "dev": true,
+            "dependencies": {
+                "@types/estree": "^1.0.0",
+                "estree-walker": "^2.0.2",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@sinclair/typebox": {
@@ -1897,6 +1935,12 @@
             "dependencies": {
                 "@babel/types": "^7.3.0"
             }
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+            "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
+            "dev": true
         },
         "node_modules/@types/graceful-fs": {
             "version": "4.1.5",
@@ -2290,6 +2334,18 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dev": true,
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
         "node_modules/ansi-escapes": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -2596,6 +2652,22 @@
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "dev": true
         },
+        "node_modules/c12": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/c12/-/c12-1.1.0.tgz",
+            "integrity": "sha512-9KRFWEng+TH8sGST4NNdiKzZGw1Z1CHnPGAmNqAyVP7suluROmBjD8hsiR34f94DdlrvtGvvmiGDsoFXlCBWIw==",
+            "dev": true,
+            "dependencies": {
+                "defu": "^6.1.1",
+                "dotenv": "^16.0.3",
+                "giget": "^1.0.0",
+                "jiti": "^1.16.0",
+                "mlly": "^1.0.0",
+                "pathe": "^1.0.0",
+                "pkg-types": "^1.0.1",
+                "rc9": "^2.0.0"
+            }
+        },
         "node_modules/callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2705,6 +2777,15 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/chownr": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/ci-info": {
             "version": "3.4.0",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.4.0.tgz",
@@ -2777,10 +2858,22 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
+        "node_modules/colorette": {
+            "version": "2.0.19",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+            "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
+            "dev": true
+        },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true
+        },
+        "node_modules/consola": {
+            "version": "2.15.3",
+            "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
+            "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
             "dev": true
         },
         "node_modules/convert-source-map": {
@@ -2792,18 +2885,24 @@
                 "safe-buffer": "~5.1.1"
             }
         },
-        "node_modules/convert-source-map/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true
-        },
         "node_modules/core-js": {
             "version": "2.6.12",
             "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
             "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
             "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
             "hasInstallScript": true
+        },
+        "node_modules/core-util-is": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+            "dev": true
+        },
+        "node_modules/create-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+            "dev": true
         },
         "node_modules/crelt": {
             "version": "1.0.5",
@@ -2879,6 +2978,22 @@
             "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.5.tgz",
             "integrity": "sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA=="
         },
+        "node_modules/debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/dedent": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -2898,6 +3013,18 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
             "integrity": "sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ=="
+        },
+        "node_modules/defu": {
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
+            "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==",
+            "dev": true
+        },
+        "node_modules/destr": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/destr/-/destr-1.2.2.tgz",
+            "integrity": "sha512-lrbCJwD9saUQrqUfXvl6qoM+QN3W7tLV5pAOs+OqOmopCCz/JkE05MHedJR1xfk4IAnZuJXPVuN5+7jNA2ZCiA==",
+            "dev": true
         },
         "node_modules/detect-newline": {
             "version": "3.1.0",
@@ -2938,10 +3065,31 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
+        "node_modules/dir-glob": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+            "dev": true,
+            "dependencies": {
+                "path-type": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/dlv": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
             "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
+        },
+        "node_modules/dotenv": {
+            "version": "16.0.3",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+            "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/elastic-builder": {
             "version": "2.16.0",
@@ -3007,6 +3155,32 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true
+        },
+        "node_modules/enhanced-resolve": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
+            "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
+            "dev": true,
+            "dependencies": {
+                "graceful-fs": "^4.1.2",
+                "memory-fs": "^0.5.0",
+                "tapable": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/errno": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+            "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
+            "dev": true,
+            "dependencies": {
+                "prr": "~1.0.1"
+            },
+            "bin": {
+                "errno": "cli.js"
+            }
         },
         "node_modules/error-ex": {
             "version": "1.3.2",
@@ -3216,6 +3390,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/flat": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+            "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+            "dev": true,
+            "bin": {
+                "flat": "cli.js"
+            }
+        },
         "node_modules/fraction.js": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
@@ -3241,6 +3424,30 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/fs-minipass": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+            "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+            "dev": true,
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/fs-minipass/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "dev": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/fs.realpath": {
@@ -3314,6 +3521,24 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/giget": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/giget/-/giget-1.0.0.tgz",
+            "integrity": "sha512-KWELZn3Nxq5+0So485poHrFriK9Bn3V/x9y+wgqrHkbmnGbjfLmZ685/SVA/ovW+ewoqW0gVI47pI4yW/VNobQ==",
+            "dev": true,
+            "dependencies": {
+                "colorette": "^2.0.19",
+                "defu": "^6.1.1",
+                "https-proxy-agent": "^5.0.1",
+                "mri": "^1.2.0",
+                "node-fetch-native": "^1.0.1",
+                "pathe": "^1.0.0",
+                "tar": "^6.1.12"
+            },
+            "bin": {
+                "giget": "dist/cli.mjs"
+            }
+        },
         "node_modules/glob": {
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -3354,6 +3579,25 @@
                 "node": ">=4"
             }
         },
+        "node_modules/globby": {
+            "version": "13.1.3",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.3.tgz",
+            "integrity": "sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==",
+            "dev": true,
+            "dependencies": {
+                "dir-glob": "^3.0.1",
+                "fast-glob": "^3.2.11",
+                "ignore": "^5.2.0",
+                "merge2": "^1.4.1",
+                "slash": "^4.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/graceful-fs": {
             "version": "4.2.10",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -3378,10 +3622,22 @@
                 "node": ">=8"
             }
         },
+        "node_modules/hash-sum": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
+            "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
+            "dev": true
+        },
         "node_modules/headers-utils": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/headers-utils/-/headers-utils-3.0.2.tgz",
             "integrity": "sha512-xAxZkM1dRyGV2Ou5bzMxBPNLoRCjcX+ya7KSWybQD2KwLphxsapUVK6x/02o7f4VU6GPSXch9vNY2+gkU8tYWQ=="
+        },
+        "node_modules/hookable": {
+            "version": "5.4.2",
+            "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.4.2.tgz",
+            "integrity": "sha512-6rOvaUiNKy9lET1X0ECnyZ5O5kSV0PJbtA5yZUgdEF7fGJEVwSLSislltyt7nFwVVALYHQJtfGeAR2Y0A0uJkg==",
+            "dev": true
         },
         "node_modules/hpagent": {
             "version": "1.0.0",
@@ -3397,6 +3653,19 @@
             "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
             "dev": true
         },
+        "node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dev": true,
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/human-signals": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -3404,6 +3673,15 @@
             "dev": true,
             "engines": {
                 "node": ">=10.17.0"
+            }
+        },
+        "node_modules/ignore": {
+            "version": "5.2.4",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+            "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 4"
             }
         },
         "node_modules/immutable": {
@@ -3541,6 +3819,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+            "dev": true
+        },
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3599,29 +3883,6 @@
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/istanbul-lib-source-maps/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/istanbul-lib-source-maps/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
         },
         "node_modules/istanbul-reports": {
             "version": "3.1.5",
@@ -4339,6 +4600,15 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
+        "node_modules/jiti": {
+            "version": "1.16.2",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.16.2.tgz",
+            "integrity": "sha512-OKBOVWmU3FxDt/UH4zSwiKPuc1nihFZiOD722FuJlngvLz2glX1v2/TJIgoA4+mrpnXxHV6dSAoCvPcYQtoG5A==",
+            "dev": true,
+            "bin": {
+                "jiti": "bin/jiti.js"
+            }
+        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4377,9 +4647,9 @@
             "dev": true
         },
         "node_modules/json5": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-            "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
             "dev": true,
             "bin": {
                 "json5": "lib/cli.js"
@@ -4387,6 +4657,12 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/jsonc-parser": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+            "dev": true
         },
         "node_modules/jsonfile": {
             "version": "6.1.0",
@@ -4407,6 +4683,12 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/knitwork": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/knitwork/-/knitwork-1.0.0.tgz",
+            "integrity": "sha512-dWl0Dbjm6Xm+kDxhPQJsCBTxrJzuGl0aP9rhr+TG8D3l+GL90N8O8lYUi7dTSAN2uuDqCtNgb6aEuQH5wsiV8Q==",
+            "dev": true
         },
         "node_modules/leaflet": {
             "version": "1.9.3",
@@ -4444,6 +4726,18 @@
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "dev": true
         },
+        "node_modules/local-pkg": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.3.tgz",
+            "integrity": "sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==",
+            "dev": true,
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
         "node_modules/locate-path": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -4475,6 +4769,12 @@
                 "lodash": "*",
                 "lodash-es": "*"
             }
+        },
+        "node_modules/lodash._reinterpolate": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+            "integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==",
+            "dev": true
         },
         "node_modules/lodash.has": {
             "version": "4.5.2",
@@ -4515,6 +4815,25 @@
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
             "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg=="
+        },
+        "node_modules/lodash.template": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+            "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
+            "dev": true,
+            "dependencies": {
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.templatesettings": "^4.0.0"
+            }
+        },
+        "node_modules/lodash.templatesettings": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+            "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
+            "dev": true,
+            "dependencies": {
+                "lodash._reinterpolate": "^3.0.0"
+            }
         },
         "node_modules/lru-cache": {
             "version": "6.0.0",
@@ -4564,6 +4883,19 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
             "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
+        },
+        "node_modules/memory-fs": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
+            "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
+            "dev": true,
+            "dependencies": {
+                "errno": "^0.1.3",
+                "readable-stream": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=4.3.0 <5.0.0 || >=5.10"
+            }
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
@@ -4617,6 +4949,90 @@
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
             "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
         },
+        "node_modules/minipass": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.0.3.tgz",
+            "integrity": "sha512-OW2r4sQ0sI+z5ckEt5c1Tri4xTgZwYDxpE54eqWlQloQRoWtXjqt9udJ5Z4dSv7wK+nfFI7FRXyCpBSft+gpFw==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minizlib": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+            "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+            "dev": true,
+            "dependencies": {
+                "minipass": "^3.0.0",
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/minizlib/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "dev": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/mkdirp": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+            "dev": true,
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/mlly": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.1.0.tgz",
+            "integrity": "sha512-cwzBrBfwGC1gYJyfcy8TcZU1f+dbH/T+TuOhtYP2wLv/Fb51/uV7HJQfBPtEupZ2ORLRU1EKFS/QfS3eo9+kBQ==",
+            "dev": true,
+            "dependencies": {
+                "acorn": "^8.8.1",
+                "pathe": "^1.0.0",
+                "pkg-types": "^1.0.1",
+                "ufo": "^1.0.1"
+            }
+        },
+        "node_modules/mlly/node_modules/acorn": {
+            "version": "8.8.2",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+            "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+            "dev": true,
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/mri": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+            "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
         "node_modules/nanoid": {
             "version": "3.3.4",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
@@ -4652,6 +5068,12 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/node-fetch-native": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.0.1.tgz",
+            "integrity": "sha512-VzW+TAk2wE4X9maiKMlT+GsPU4OMmR1U9CrHSmd3DFLn2IcZ9VJ6M6BBugGfYUnPCLSYxXdZy17M0BEJyhUTwg==",
+            "dev": true
         },
         "node_modules/node-int64": {
             "version": "0.4.0",
@@ -4817,6 +5239,21 @@
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
         },
+        "node_modules/path-type": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/pathe": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.0.tgz",
+            "integrity": "sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==",
+            "dev": true
+        },
         "node_modules/picocolors": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -4862,6 +5299,17 @@
                 "node": ">=8"
             }
         },
+        "node_modules/pkg-types": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.1.tgz",
+            "integrity": "sha512-jHv9HB+Ho7dj6ItwppRDDl0iZRYBD0jsakHXtFgoLr+cHSF6xC+QL54sJmWxyGxOLYSHm0afhXhXcQDQqH9z8g==",
+            "dev": true,
+            "dependencies": {
+                "jsonc-parser": "^3.2.0",
+                "mlly": "^1.0.0",
+                "pathe": "^1.0.0"
+            }
+        },
         "node_modules/postcss": {
             "version": "8.4.21",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
@@ -4899,6 +5347,15 @@
             },
             "peerDependencies": {
                 "postcss": "^8.0.0"
+            }
+        },
+        "node_modules/postcss-import-resolver": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-import-resolver/-/postcss-import-resolver-2.0.0.tgz",
+            "integrity": "sha512-y001XYgGvVwgxyxw9J1a5kqM/vtmIQGzx34g0A0Oy44MFcy/ZboZw1hu/iN3VYFjSTRzbvd7zZJJz0Kh0AGkTw==",
+            "dev": true,
+            "dependencies": {
+                "enhanced-resolve": "^4.1.1"
             }
         },
         "node_modules/postcss-js": {
@@ -5017,6 +5474,12 @@
                 "node": ">= 0.6.0"
             }
         },
+        "node_modules/process-nextick-args": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "dev": true
+        },
         "node_modules/prompts": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -5029,6 +5492,12 @@
             "engines": {
                 "node": ">= 6"
             }
+        },
+        "node_modules/prr": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+            "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
+            "dev": true
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
@@ -5060,6 +5529,17 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/rc9": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.0.1.tgz",
+            "integrity": "sha512-9EfjLgNmzP9255YX8bGnILQcmdtOXKtUlFTu8bOZPJVtaUDZ2imswcUdpK51tMjTRQyB7r5RebNijrzuyGXcVA==",
+            "dev": true,
+            "dependencies": {
+                "defu": "^6.1.2",
+                "destr": "^1.2.2",
+                "flat": "^5.0.2"
+            }
+        },
         "node_modules/react-is": {
             "version": "18.2.0",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -5072,6 +5552,21 @@
             "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
             "dependencies": {
                 "pify": "^2.3.0"
+            }
+        },
+        "node_modules/readable-stream": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "dev": true,
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
             }
         },
         "node_modules/readdirp": {
@@ -5193,6 +5688,12 @@
                 "queue-microtask": "^1.2.2"
             }
         },
+        "node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
+        },
         "node_modules/sass": {
             "version": "1.57.1",
             "resolved": "https://registry.npmjs.org/sass/-/sass-1.57.1.tgz",
@@ -5209,6 +5710,12 @@
             "engines": {
                 "node": ">=12.0.0"
             }
+        },
+        "node_modules/scule": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/scule/-/scule-1.0.0.tgz",
+            "integrity": "sha512-4AsO/FrViE/iDNEPaAQlb77tf0csuq27EsVpy6ett584EcRTp6pTDLoGWVxCD77y5iU5FauOvhsI4o1APwPoSQ==",
+            "dev": true
         },
         "node_modules/secure-json-parse": {
             "version": "2.5.0",
@@ -5256,6 +5763,18 @@
             "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
             "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
             "dev": true
+        },
+        "node_modules/slash": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+            "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/source-map": {
             "version": "0.6.1",
@@ -5315,6 +5834,21 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/std-env": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.3.2.tgz",
+            "integrity": "sha512-uUZI65yrV2Qva5gqE0+A7uVAvO40iPo6jGhs7s8keRfHCmtg+uB2X6EiLGCI9IgL1J17xGhvoOqSz79lzICPTA==",
+            "dev": true
+        },
+        "node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
             }
         },
         "node_modules/string-length": {
@@ -5386,6 +5920,30 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/strip-literal": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-1.0.1.tgz",
+            "integrity": "sha512-QZTsipNpa2Ppr6v1AmJHESqJ3Uz247MUS0OjrnnZjFAvEoWqxuyFuXn2xLgMtRnijJShAa1HL0gtJyUs7u7n3Q==",
+            "dev": true,
+            "dependencies": {
+                "acorn": "^8.8.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/strip-literal/node_modules/acorn": {
+            "version": "8.8.2",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+            "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+            "dev": true,
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
         "node_modules/style-mod": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.0.tgz",
@@ -5451,6 +6009,32 @@
             },
             "peerDependencies": {
                 "postcss": "^8.0.9"
+            }
+        },
+        "node_modules/tapable": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+            "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/tar": {
+            "version": "6.1.13",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
+            "integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
+            "dev": true,
+            "dependencies": {
+                "chownr": "^2.0.0",
+                "fs-minipass": "^2.0.0",
+                "minipass": "^4.0.0",
+                "minizlib": "^2.1.1",
+                "mkdirp": "^1.0.3",
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/terser": {
@@ -5566,6 +6150,57 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/ufo": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
+            "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
+            "dev": true
+        },
+        "node_modules/unctx": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/unctx/-/unctx-2.1.1.tgz",
+            "integrity": "sha512-RffJlpvLOtolWsn0fxXsuSDfwiWcR6cyuykw2e0+zAggvGW1SesXt9WxIWlWpJhwVCZD/WlxxLqKLS50Q0CkWA==",
+            "dev": true,
+            "dependencies": {
+                "acorn": "^8.8.1",
+                "estree-walker": "^3.0.1",
+                "magic-string": "^0.26.7",
+                "unplugin": "^1.0.0"
+            }
+        },
+        "node_modules/unctx/node_modules/acorn": {
+            "version": "8.8.2",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+            "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+            "dev": true,
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/unctx/node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "node_modules/unctx/node_modules/magic-string": {
+            "version": "0.26.7",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
+            "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
+            "dev": true,
+            "dependencies": {
+                "sourcemap-codec": "^1.4.8"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/undici": {
             "version": "5.10.0",
             "resolved": "https://registry.npmjs.org/undici/-/undici-5.10.0.tgz",
@@ -5574,12 +6209,201 @@
                 "node": ">=12.18"
             }
         },
+        "node_modules/unimport": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/unimport/-/unimport-2.2.4.tgz",
+            "integrity": "sha512-qMgmeEGqqrrmEtm0dqxMG37J6xBtrriqxq9hILvDb+e6l2F0yTnJomLoCCp0eghLR7bYGeBsUU5Y0oyiUYhViw==",
+            "dev": true,
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.2",
+                "escape-string-regexp": "^5.0.0",
+                "fast-glob": "^3.2.12",
+                "local-pkg": "^0.4.3",
+                "magic-string": "^0.27.0",
+                "mlly": "^1.1.0",
+                "pathe": "^1.1.0",
+                "pkg-types": "^1.0.1",
+                "scule": "^1.0.0",
+                "strip-literal": "^1.0.0",
+                "unplugin": "^1.0.1"
+            }
+        },
+        "node_modules/unimport/node_modules/escape-string-regexp": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/unimport/node_modules/magic-string": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+            "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.4.13"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/universalify": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
             "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
             "engines": {
                 "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/unplugin": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.0.1.tgz",
+            "integrity": "sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==",
+            "dev": true,
+            "dependencies": {
+                "acorn": "^8.8.1",
+                "chokidar": "^3.5.3",
+                "webpack-sources": "^3.2.3",
+                "webpack-virtual-modules": "^0.5.0"
+            }
+        },
+        "node_modules/unplugin-auto-import": {
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/unplugin-auto-import/-/unplugin-auto-import-0.13.0.tgz",
+            "integrity": "sha512-nKMxDbkjM4FRPInFfm7sWrJOKgxfKKwb5yLPP+DEGl/SG0/FtBoW1LnZL4PQfx0FXjertoHO1P/5nDf+RSip2Q==",
+            "dev": true,
+            "dependencies": {
+                "@antfu/utils": "^0.7.2",
+                "@rollup/pluginutils": "^5.0.2",
+                "local-pkg": "^0.4.3",
+                "magic-string": "^0.27.0",
+                "unimport": "^2.1.0",
+                "unplugin": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "@vueuse/core": "*"
+            },
+            "peerDependenciesMeta": {
+                "@vueuse/core": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/unplugin-auto-import/node_modules/magic-string": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+            "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.4.13"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/unplugin-vue-components": {
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/unplugin-vue-components/-/unplugin-vue-components-0.23.0.tgz",
+            "integrity": "sha512-JAJ+BGvjHvi9P7lICwOzDx2Av+OcI6ZTzvySmjXDNGCNVPrt2NQQmbcp7cW027CR1mRugIX5G//awm3doHyqkg==",
+            "dev": true,
+            "dependencies": {
+                "@antfu/utils": "^0.7.2",
+                "@nuxt/kit": "^3.1.1",
+                "@rollup/pluginutils": "^5.0.2",
+                "chokidar": "^3.5.3",
+                "debug": "^4.3.4",
+                "fast-glob": "^3.2.12",
+                "local-pkg": "^0.4.3",
+                "magic-string": "^0.27.0",
+                "minimatch": "^6.1.6",
+                "resolve": "^1.22.1",
+                "unplugin": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "@babel/parser": "^7.15.8",
+                "vue": "2 || 3"
+            },
+            "peerDependenciesMeta": {
+                "@babel/parser": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/unplugin-vue-components/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/unplugin-vue-components/node_modules/magic-string": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+            "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.4.13"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/unplugin-vue-components/node_modules/minimatch": {
+            "version": "6.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.1.6.tgz",
+            "integrity": "sha512-6bR3UIeh/DF8+p6A9Spyuy67ShOq42rOkHWi7eUe3Ua99Zo5lZfGC6lJJWkeoK4k9jQFT3Pl7czhTXimG2XheA==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/unplugin/node_modules/acorn": {
+            "version": "8.8.2",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+            "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+            "dev": true,
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/untyped": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/untyped/-/untyped-1.2.2.tgz",
+            "integrity": "sha512-EANYd5L6AdpgfldlgMcmvOOnj092nWhy0ybhc7uhEH12ipytDYz89EOegBQKj8qWL3u1wgYnmFjADhsuCJs5Aw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/core": "^7.20.12",
+                "@babel/standalone": "^7.20.12",
+                "@babel/types": "^7.20.7",
+                "scule": "^1.0.0"
             }
         },
         "node_modules/update-browserslist-db": {
@@ -5748,6 +6572,21 @@
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
             "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
         },
+        "node_modules/webpack-sources": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+            "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+            "dev": true,
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/webpack-virtual-modules": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz",
+            "integrity": "sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==",
+            "dev": true
+        },
         "node_modules/whatwg-url": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -5902,6 +6741,12 @@
                 }
             }
         },
+        "@antfu/utils": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-0.7.2.tgz",
+            "integrity": "sha512-vy9fM3pIxZmX07dL+VX1aZe7ynZ+YyB0jY+jE6r3hOK6GNY2t6W8rzpFC4tgpbXUYABkFQwgJq2XYXlxbXAI0g==",
+            "dev": true
+        },
         "@babel/code-frame": {
             "version": "7.18.6",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
@@ -5912,72 +6757,73 @@
             }
         },
         "@babel/compat-data": {
-            "version": "7.20.1",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.1.tgz",
-            "integrity": "sha512-EWZ4mE2diW3QALKvDMiXnbZpRvlj+nayZ112nK93SnhqOtpdsbVD4W+2tEoT3YNBAG9RBR0ISY758ZkOgsn6pQ==",
+            "version": "7.20.14",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.14.tgz",
+            "integrity": "sha512-0YpKHD6ImkWMEINCyDAD0HLLUH/lPCefG8ld9it8DJB2wnApraKuhgYTvTY1z7UFIfBTGy5LwncZ+5HWWGbhFw==",
             "dev": true
         },
         "@babel/core": {
-            "version": "7.19.1",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.1.tgz",
-            "integrity": "sha512-1H8VgqXme4UXCRv7/Wa1bq7RVymKOzC7znjyFM8KiEzwFqcKUKYNoQef4GhdklgNvoBXyW4gYhuBNCM5o1zImw==",
+            "version": "7.20.12",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz",
+            "integrity": "sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==",
             "dev": true,
             "requires": {
                 "@ampproject/remapping": "^2.1.0",
                 "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.19.0",
-                "@babel/helper-compilation-targets": "^7.19.1",
-                "@babel/helper-module-transforms": "^7.19.0",
-                "@babel/helpers": "^7.19.0",
-                "@babel/parser": "^7.19.1",
-                "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.19.1",
-                "@babel/types": "^7.19.0",
+                "@babel/generator": "^7.20.7",
+                "@babel/helper-compilation-targets": "^7.20.7",
+                "@babel/helper-module-transforms": "^7.20.11",
+                "@babel/helpers": "^7.20.7",
+                "@babel/parser": "^7.20.7",
+                "@babel/template": "^7.20.7",
+                "@babel/traverse": "^7.20.12",
+                "@babel/types": "^7.20.7",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
-                "json5": "^2.2.1",
+                "json5": "^2.2.2",
                 "semver": "^6.3.0"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-                    "dev": true
-                }
             }
         },
         "@babel/generator": {
-            "version": "7.20.4",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.4.tgz",
-            "integrity": "sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==",
+            "version": "7.20.14",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.14.tgz",
+            "integrity": "sha512-AEmuXHdcD3A52HHXxaTmYlb8q/xMEhoRP67B3T4Oq7lbmSoqroMZzjnGj3+i1io3pdnF8iBYVu4Ilj+c4hBxYg==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.20.2",
+                "@babel/types": "^7.20.7",
                 "@jridgewell/gen-mapping": "^0.3.2",
                 "jsesc": "^2.5.1"
             }
         },
         "@babel/helper-compilation-targets": {
-            "version": "7.20.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.0.tgz",
-            "integrity": "sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==",
+            "version": "7.20.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
+            "integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
             "dev": true,
             "requires": {
-                "@babel/compat-data": "^7.20.0",
+                "@babel/compat-data": "^7.20.5",
                 "@babel/helper-validator-option": "^7.18.6",
                 "browserslist": "^4.21.3",
+                "lru-cache": "^5.1.1",
                 "semver": "^6.3.0"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+                    "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^3.0.2"
+                    }
+                },
+                "yallist": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+                    "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+                    "dev": true
+                }
             }
         },
         "@babel/helper-environment-visitor": {
@@ -6015,9 +6861,9 @@
             }
         },
         "@babel/helper-module-transforms": {
-            "version": "7.20.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.2.tgz",
-            "integrity": "sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==",
+            "version": "7.20.11",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz",
+            "integrity": "sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==",
             "dev": true,
             "requires": {
                 "@babel/helper-environment-visitor": "^7.18.9",
@@ -6025,9 +6871,9 @@
                 "@babel/helper-simple-access": "^7.20.2",
                 "@babel/helper-split-export-declaration": "^7.18.6",
                 "@babel/helper-validator-identifier": "^7.19.1",
-                "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.20.1",
-                "@babel/types": "^7.20.2"
+                "@babel/template": "^7.20.7",
+                "@babel/traverse": "^7.20.10",
+                "@babel/types": "^7.20.7"
             }
         },
         "@babel/helper-plugin-utils": {
@@ -6073,14 +6919,14 @@
             "dev": true
         },
         "@babel/helpers": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.19.0.tgz",
-            "integrity": "sha512-DRBCKGwIEdqY3+rPJgG/dKfQy9+08rHIAJx8q2p+HSWP87s2HCrQmaAMMyMll2kIXKCW0cO1RdQskx15Xakftg==",
+            "version": "7.20.13",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.13.tgz",
+            "integrity": "sha512-nzJ0DWCL3gB5RCXbUO3KIMMsBY2Eqbx8mBpKGE/02PgyRQFcPQLbkQ1vyy596mZLaP+dAfD+R4ckASzNVmW3jg==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.19.0",
-                "@babel/types": "^7.19.0"
+                "@babel/template": "^7.20.7",
+                "@babel/traverse": "^7.20.13",
+                "@babel/types": "^7.20.7"
             }
         },
         "@babel/highlight": {
@@ -6147,9 +6993,9 @@
             }
         },
         "@babel/parser": {
-            "version": "7.20.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.3.tgz",
-            "integrity": "sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg=="
+            "version": "7.20.15",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.15.tgz",
+            "integrity": "sha512-DI4a1oZuf8wC+oAJA9RW6ga3Zbe8RZFt7kD9i4qAspz3I/yHet1VvC3DiSy/fsUvv5pvJuNPh0LPOdCcqinDPg=="
         },
         "@babel/plugin-syntax-async-generators": {
             "version": "7.8.4",
@@ -6277,56 +7123,45 @@
                 "@babel/helper-plugin-utils": "^7.19.0"
             }
         },
+        "@babel/standalone": {
+            "version": "7.20.15",
+            "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.20.15.tgz",
+            "integrity": "sha512-B3LmZ1NHlTb2eFEaw8rftZc730Wh9MlmsH8ubb6IjsNoIk9+SQ2aAA0nrm/1806+PftPRAACPClmKTu8PG7Tew==",
+            "dev": true
+        },
         "@babel/template": {
-            "version": "7.18.10",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
-            "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
+            "version": "7.20.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
+            "integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.18.6",
-                "@babel/parser": "^7.18.10",
-                "@babel/types": "^7.18.10"
+                "@babel/parser": "^7.20.7",
+                "@babel/types": "^7.20.7"
             }
         },
         "@babel/traverse": {
-            "version": "7.20.1",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.1.tgz",
-            "integrity": "sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==",
+            "version": "7.20.13",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.13.tgz",
+            "integrity": "sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.20.1",
+                "@babel/generator": "^7.20.7",
                 "@babel/helper-environment-visitor": "^7.18.9",
                 "@babel/helper-function-name": "^7.19.0",
                 "@babel/helper-hoist-variables": "^7.18.6",
                 "@babel/helper-split-export-declaration": "^7.18.6",
-                "@babel/parser": "^7.20.1",
-                "@babel/types": "^7.20.0",
+                "@babel/parser": "^7.20.13",
+                "@babel/types": "^7.20.7",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-                    "dev": true
-                }
             }
         },
         "@babel/types": {
-            "version": "7.20.2",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.2.tgz",
-            "integrity": "sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==",
+            "version": "7.20.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.7.tgz",
+            "integrity": "sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==",
             "dev": true,
             "requires": {
                 "@babel/helper-string-parser": "^7.19.4",
@@ -6466,21 +7301,6 @@
                     "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
                     "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
                 },
-                "debug": {
-                    "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-                    "requires": {
-                        "ms": "2.1.2"
-                    },
-                    "dependencies": {
-                        "ms": {
-                            "version": "2.1.2",
-                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-                        }
-                    }
-                },
                 "hpagent": {
                     "version": "0.1.2",
                     "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-0.1.2.tgz",
@@ -6534,21 +7354,6 @@
                 "undici": "^5.1.1"
             },
             "dependencies": {
-                "debug": {
-                    "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-                    "requires": {
-                        "ms": "2.1.2"
-                    },
-                    "dependencies": {
-                        "ms": {
-                            "version": "2.1.2",
-                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-                        }
-                    }
-                },
                 "ms": {
                     "version": "2.1.3",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -7170,10 +7975,79 @@
                 "fastq": "^1.6.0"
             }
         },
+        "@nuxt/kit": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.1.2.tgz",
+            "integrity": "sha512-m8/AF8hBJiG7aTx2CpiDGeLYYz30fUoPbJ9XiSmHqRIXv1goAFWHSkzWfRNEsoAAbMHf76oB917wVUQ3VSSQHg==",
+            "dev": true,
+            "requires": {
+                "@nuxt/schema": "3.1.2",
+                "c12": "^1.1.0",
+                "consola": "^2.15.3",
+                "defu": "^6.1.2",
+                "globby": "^13.1.3",
+                "hash-sum": "^2.0.0",
+                "ignore": "^5.2.4",
+                "jiti": "^1.16.2",
+                "knitwork": "^1.0.0",
+                "lodash.template": "^4.5.0",
+                "mlly": "^1.1.0",
+                "pathe": "^1.1.0",
+                "pkg-types": "^1.0.1",
+                "scule": "^1.0.0",
+                "semver": "^7.3.8",
+                "unctx": "^2.1.1",
+                "unimport": "^2.1.0",
+                "untyped": "^1.2.2"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "7.3.8",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+                    "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                }
+            }
+        },
+        "@nuxt/schema": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.1.2.tgz",
+            "integrity": "sha512-wru9LhRXTa6WQlx7c0oYrtvJY7TiVlkBKXY5Rsmfo0StJuWohgZiReu9fu6z6GU4MzZlX25TVjwvq9Q7bNVbSQ==",
+            "dev": true,
+            "requires": {
+                "c12": "^1.1.0",
+                "create-require": "^1.1.1",
+                "defu": "^6.1.2",
+                "hookable": "^5.4.2",
+                "jiti": "^1.16.2",
+                "pathe": "^1.1.0",
+                "pkg-types": "^1.0.1",
+                "postcss-import-resolver": "^2.0.0",
+                "scule": "^1.0.0",
+                "std-env": "^3.3.2",
+                "ufo": "^1.0.1",
+                "unimport": "^2.1.0",
+                "untyped": "^1.2.2"
+            }
+        },
         "@popperjs/core": {
             "version": "npm:@sxzz/popperjs-es@2.11.7",
             "resolved": "https://registry.npmjs.org/@sxzz/popperjs-es/-/popperjs-es-2.11.7.tgz",
             "integrity": "sha512-Ccy0NlLkzr0Ex2FKvh2X+OyERHXJ88XJ1MXtsI9y9fGexlaXaVTPzBCRBwIxFkORuOb+uBqeu+RqnpgYTEZRUQ=="
+        },
+        "@rollup/pluginutils": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
+            "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+            "dev": true,
+            "requires": {
+                "@types/estree": "^1.0.0",
+                "estree-walker": "^2.0.2",
+                "picomatch": "^2.3.1"
+            }
         },
         "@sinclair/typebox": {
             "version": "0.24.44",
@@ -7239,6 +8113,12 @@
             "requires": {
                 "@babel/types": "^7.3.0"
             }
+        },
+        "@types/estree": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+            "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
+            "dev": true
         },
         "@types/graceful-fs": {
             "version": "4.1.5",
@@ -7558,6 +8438,15 @@
             "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
             "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
         },
+        "agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dev": true,
+            "requires": {
+                "debug": "4"
+            }
+        },
         "ansi-escapes": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -7782,6 +8671,22 @@
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "dev": true
         },
+        "c12": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/c12/-/c12-1.1.0.tgz",
+            "integrity": "sha512-9KRFWEng+TH8sGST4NNdiKzZGw1Z1CHnPGAmNqAyVP7suluROmBjD8hsiR34f94DdlrvtGvvmiGDsoFXlCBWIw==",
+            "dev": true,
+            "requires": {
+                "defu": "^6.1.1",
+                "dotenv": "^16.0.3",
+                "giget": "^1.0.0",
+                "jiti": "^1.16.0",
+                "mlly": "^1.0.0",
+                "pathe": "^1.0.0",
+                "pkg-types": "^1.0.1",
+                "rc9": "^2.0.0"
+            }
+        },
         "callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -7851,6 +8756,12 @@
                 }
             }
         },
+        "chownr": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+            "dev": true
+        },
         "ci-info": {
             "version": "3.4.0",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.4.0.tgz",
@@ -7913,10 +8824,22 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
+        "colorette": {
+            "version": "2.0.19",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+            "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
+            "dev": true
+        },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true
+        },
+        "consola": {
+            "version": "2.15.3",
+            "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
+            "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
             "dev": true
         },
         "convert-source-map": {
@@ -7926,20 +8849,24 @@
             "dev": true,
             "requires": {
                 "safe-buffer": "~5.1.1"
-            },
-            "dependencies": {
-                "safe-buffer": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-                    "dev": true
-                }
             }
         },
         "core-js": {
             "version": "2.6.12",
             "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
             "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+        },
+        "core-util-is": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+            "dev": true
+        },
+        "create-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+            "dev": true
         },
         "crelt": {
             "version": "1.0.5",
@@ -7993,6 +8920,14 @@
             "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.5.tgz",
             "integrity": "sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA=="
         },
+        "debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "requires": {
+                "ms": "2.1.2"
+            }
+        },
         "dedent": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -8009,6 +8944,18 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
             "integrity": "sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ=="
+        },
+        "defu": {
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
+            "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==",
+            "dev": true
+        },
+        "destr": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/destr/-/destr-1.2.2.tgz",
+            "integrity": "sha512-lrbCJwD9saUQrqUfXvl6qoM+QN3W7tLV5pAOs+OqOmopCCz/JkE05MHedJR1xfk4IAnZuJXPVuN5+7jNA2ZCiA==",
+            "dev": true
         },
         "detect-newline": {
             "version": "3.1.0",
@@ -8037,10 +8984,25 @@
             "integrity": "sha512-hlM3QR272NXCi4pq+N4Kok4kOp6EsgOM3ZSpJI7Da3UAs+Ttsi8MRmB6trM/lhyzUxGfOgnpkHtgqm5Q/CTcfQ==",
             "dev": true
         },
+        "dir-glob": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+            "dev": true,
+            "requires": {
+                "path-type": "^4.0.0"
+            }
+        },
         "dlv": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
             "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
+        },
+        "dotenv": {
+            "version": "16.0.3",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+            "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+            "dev": true
         },
         "elastic-builder": {
             "version": "2.16.0",
@@ -8097,6 +9059,26 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true
+        },
+        "enhanced-resolve": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
+            "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "memory-fs": "^0.5.0",
+                "tapable": "^1.0.0"
+            }
+        },
+        "errno": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+            "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
+            "dev": true,
+            "requires": {
+                "prr": "~1.0.1"
+            }
         },
         "error-ex": {
             "version": "1.3.2",
@@ -8264,6 +9246,12 @@
                 "path-exists": "^4.0.0"
             }
         },
+        "flat": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+            "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+            "dev": true
+        },
         "fraction.js": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
@@ -8279,6 +9267,26 @@
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^6.0.1",
                 "universalify": "^2.0.0"
+            }
+        },
+        "fs-minipass": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+            "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+            "dev": true,
+            "requires": {
+                "minipass": "^3.0.0"
+            },
+            "dependencies": {
+                "minipass": {
+                    "version": "3.3.6",
+                    "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+                    "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                }
             }
         },
         "fs.realpath": {
@@ -8327,6 +9335,21 @@
             "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
             "dev": true
         },
+        "giget": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/giget/-/giget-1.0.0.tgz",
+            "integrity": "sha512-KWELZn3Nxq5+0So485poHrFriK9Bn3V/x9y+wgqrHkbmnGbjfLmZ685/SVA/ovW+ewoqW0gVI47pI4yW/VNobQ==",
+            "dev": true,
+            "requires": {
+                "colorette": "^2.0.19",
+                "defu": "^6.1.1",
+                "https-proxy-agent": "^5.0.1",
+                "mri": "^1.2.0",
+                "node-fetch-native": "^1.0.1",
+                "pathe": "^1.0.0",
+                "tar": "^6.1.12"
+            }
+        },
         "glob": {
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -8355,6 +9378,19 @@
             "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
             "dev": true
         },
+        "globby": {
+            "version": "13.1.3",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.3.tgz",
+            "integrity": "sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==",
+            "dev": true,
+            "requires": {
+                "dir-glob": "^3.0.1",
+                "fast-glob": "^3.2.11",
+                "ignore": "^5.2.0",
+                "merge2": "^1.4.1",
+                "slash": "^4.0.0"
+            }
+        },
         "graceful-fs": {
             "version": "4.2.10",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -8373,10 +9409,22 @@
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
+        "hash-sum": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
+            "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
+            "dev": true
+        },
         "headers-utils": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/headers-utils/-/headers-utils-3.0.2.tgz",
             "integrity": "sha512-xAxZkM1dRyGV2Ou5bzMxBPNLoRCjcX+ya7KSWybQD2KwLphxsapUVK6x/02o7f4VU6GPSXch9vNY2+gkU8tYWQ=="
+        },
+        "hookable": {
+            "version": "5.4.2",
+            "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.4.2.tgz",
+            "integrity": "sha512-6rOvaUiNKy9lET1X0ECnyZ5O5kSV0PJbtA5yZUgdEF7fGJEVwSLSislltyt7nFwVVALYHQJtfGeAR2Y0A0uJkg==",
+            "dev": true
         },
         "hpagent": {
             "version": "1.0.0",
@@ -8389,10 +9437,26 @@
             "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
             "dev": true
         },
+        "https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dev": true,
+            "requires": {
+                "agent-base": "6",
+                "debug": "4"
+            }
+        },
         "human-signals": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
             "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+            "dev": true
+        },
+        "ignore": {
+            "version": "5.2.4",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+            "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
             "dev": true
         },
         "immutable": {
@@ -8491,6 +9555,12 @@
             "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
             "dev": true
         },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+            "dev": true
+        },
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -8536,23 +9606,6 @@
                 "debug": "^4.1.1",
                 "istanbul-lib-coverage": "^3.0.0",
                 "source-map": "^0.6.1"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-                    "dev": true
-                }
             }
         },
         "istanbul-reports": {
@@ -9107,6 +10160,12 @@
                 "string-length": "^4.0.1"
             }
         },
+        "jiti": {
+            "version": "1.16.2",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.16.2.tgz",
+            "integrity": "sha512-OKBOVWmU3FxDt/UH4zSwiKPuc1nihFZiOD722FuJlngvLz2glX1v2/TJIgoA4+mrpnXxHV6dSAoCvPcYQtoG5A==",
+            "dev": true
+        },
         "js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -9136,9 +10195,15 @@
             "dev": true
         },
         "json5": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-            "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "dev": true
+        },
+        "jsonc-parser": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
             "dev": true
         },
         "jsonfile": {
@@ -9154,6 +10219,12 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
             "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+            "dev": true
+        },
+        "knitwork": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/knitwork/-/knitwork-1.0.0.tgz",
+            "integrity": "sha512-dWl0Dbjm6Xm+kDxhPQJsCBTxrJzuGl0aP9rhr+TG8D3l+GL90N8O8lYUi7dTSAN2uuDqCtNgb6aEuQH5wsiV8Q==",
             "dev": true
         },
         "leaflet": {
@@ -9186,6 +10257,12 @@
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "dev": true
         },
+        "local-pkg": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.3.tgz",
+            "integrity": "sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==",
+            "dev": true
+        },
         "locate-path": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -9210,6 +10287,12 @@
             "resolved": "https://registry.npmjs.org/lodash-unified/-/lodash-unified-1.0.2.tgz",
             "integrity": "sha512-OGbEy+1P+UT26CYi4opY4gebD8cWRDxAT6MAObIVQMiqYdxZr1g3QHWCToVsm31x2NkLS4K3+MC2qInaRMa39g==",
             "requires": {}
+        },
+        "lodash._reinterpolate": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+            "integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==",
+            "dev": true
         },
         "lodash.has": {
             "version": "4.5.2",
@@ -9251,6 +10334,25 @@
             "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
             "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg=="
         },
+        "lodash.template": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+            "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
+            "dev": true,
+            "requires": {
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.templatesettings": "^4.0.0"
+            }
+        },
+        "lodash.templatesettings": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+            "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
+            "dev": true,
+            "requires": {
+                "lodash._reinterpolate": "^3.0.0"
+            }
+        },
         "lru-cache": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -9290,6 +10392,16 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
             "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
+        },
+        "memory-fs": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
+            "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
+            "dev": true,
+            "requires": {
+                "errno": "^0.1.3",
+                "readable-stream": "^2.0.1"
+            }
         },
         "merge-stream": {
             "version": "2.0.0",
@@ -9331,6 +10443,70 @@
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
             "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
         },
+        "minipass": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.0.3.tgz",
+            "integrity": "sha512-OW2r4sQ0sI+z5ckEt5c1Tri4xTgZwYDxpE54eqWlQloQRoWtXjqt9udJ5Z4dSv7wK+nfFI7FRXyCpBSft+gpFw==",
+            "dev": true
+        },
+        "minizlib": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+            "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+            "dev": true,
+            "requires": {
+                "minipass": "^3.0.0",
+                "yallist": "^4.0.0"
+            },
+            "dependencies": {
+                "minipass": {
+                    "version": "3.3.6",
+                    "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+                    "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "mkdirp": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+            "dev": true
+        },
+        "mlly": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.1.0.tgz",
+            "integrity": "sha512-cwzBrBfwGC1gYJyfcy8TcZU1f+dbH/T+TuOhtYP2wLv/Fb51/uV7HJQfBPtEupZ2ORLRU1EKFS/QfS3eo9+kBQ==",
+            "dev": true,
+            "requires": {
+                "acorn": "^8.8.1",
+                "pathe": "^1.0.0",
+                "pkg-types": "^1.0.1",
+                "ufo": "^1.0.1"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "8.8.2",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+                    "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+                    "dev": true
+                }
+            }
+        },
+        "mri": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+            "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+            "dev": true
+        },
+        "ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
         "nanoid": {
             "version": "3.3.4",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
@@ -9349,6 +10525,12 @@
             "requires": {
                 "whatwg-url": "^5.0.0"
             }
+        },
+        "node-fetch-native": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.0.1.tgz",
+            "integrity": "sha512-VzW+TAk2wE4X9maiKMlT+GsPU4OMmR1U9CrHSmd3DFLn2IcZ9VJ6M6BBugGfYUnPCLSYxXdZy17M0BEJyhUTwg==",
+            "dev": true
         },
         "node-int64": {
             "version": "0.4.0",
@@ -9469,6 +10651,18 @@
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
         },
+        "path-type": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+            "dev": true
+        },
+        "pathe": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.0.tgz",
+            "integrity": "sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==",
+            "dev": true
+        },
         "picocolors": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -9499,6 +10693,17 @@
                 "find-up": "^4.0.0"
             }
         },
+        "pkg-types": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.1.tgz",
+            "integrity": "sha512-jHv9HB+Ho7dj6ItwppRDDl0iZRYBD0jsakHXtFgoLr+cHSF6xC+QL54sJmWxyGxOLYSHm0afhXhXcQDQqH9z8g==",
+            "dev": true,
+            "requires": {
+                "jsonc-parser": "^3.2.0",
+                "mlly": "^1.0.0",
+                "pathe": "^1.0.0"
+            }
+        },
         "postcss": {
             "version": "8.4.21",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
@@ -9517,6 +10722,15 @@
                 "postcss-value-parser": "^4.0.0",
                 "read-cache": "^1.0.0",
                 "resolve": "^1.1.7"
+            }
+        },
+        "postcss-import-resolver": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-import-resolver/-/postcss-import-resolver-2.0.0.tgz",
+            "integrity": "sha512-y001XYgGvVwgxyxw9J1a5kqM/vtmIQGzx34g0A0Oy44MFcy/ZboZw1hu/iN3VYFjSTRzbvd7zZJJz0Kh0AGkTw==",
+            "dev": true,
+            "requires": {
+                "enhanced-resolve": "^4.1.1"
             }
         },
         "postcss-js": {
@@ -9583,6 +10797,12 @@
             "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
             "dev": true
         },
+        "process-nextick-args": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "dev": true
+        },
         "prompts": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -9593,6 +10813,12 @@
                 "sisteransi": "^1.0.5"
             }
         },
+        "prr": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+            "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
+            "dev": true
+        },
         "queue-microtask": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -9602,6 +10828,17 @@
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
             "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
+        },
+        "rc9": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.0.1.tgz",
+            "integrity": "sha512-9EfjLgNmzP9255YX8bGnILQcmdtOXKtUlFTu8bOZPJVtaUDZ2imswcUdpK51tMjTRQyB7r5RebNijrzuyGXcVA==",
+            "dev": true,
+            "requires": {
+                "defu": "^6.1.2",
+                "destr": "^1.2.2",
+                "flat": "^5.0.2"
+            }
         },
         "react-is": {
             "version": "18.2.0",
@@ -9615,6 +10852,21 @@
             "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
             "requires": {
                 "pify": "^2.3.0"
+            }
+        },
+        "readable-stream": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "dev": true,
+            "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
             }
         },
         "readdirp": {
@@ -9692,6 +10944,12 @@
                 "queue-microtask": "^1.2.2"
             }
         },
+        "safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
+        },
         "sass": {
             "version": "1.57.1",
             "resolved": "https://registry.npmjs.org/sass/-/sass-1.57.1.tgz",
@@ -9702,6 +10960,12 @@
                 "immutable": "^4.0.0",
                 "source-map-js": ">=0.6.2 <2.0.0"
             }
+        },
+        "scule": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/scule/-/scule-1.0.0.tgz",
+            "integrity": "sha512-4AsO/FrViE/iDNEPaAQlb77tf0csuq27EsVpy6ett584EcRTp6pTDLoGWVxCD77y5iU5FauOvhsI4o1APwPoSQ==",
+            "dev": true
         },
         "secure-json-parse": {
             "version": "2.5.0",
@@ -9739,6 +11003,12 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
             "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+            "dev": true
+        },
+        "slash": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+            "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
             "dev": true
         },
         "source-map": {
@@ -9791,6 +11061,21 @@
                 }
             }
         },
+        "std-env": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.3.2.tgz",
+            "integrity": "sha512-uUZI65yrV2Qva5gqE0+A7uVAvO40iPo6jGhs7s8keRfHCmtg+uB2X6EiLGCI9IgL1J17xGhvoOqSz79lzICPTA==",
+            "dev": true
+        },
+        "string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
         "string-length": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -9839,6 +11124,23 @@
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true
         },
+        "strip-literal": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-1.0.1.tgz",
+            "integrity": "sha512-QZTsipNpa2Ppr6v1AmJHESqJ3Uz247MUS0OjrnnZjFAvEoWqxuyFuXn2xLgMtRnijJShAa1HL0gtJyUs7u7n3Q==",
+            "dev": true,
+            "requires": {
+                "acorn": "^8.8.2"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "8.8.2",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+                    "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+                    "dev": true
+                }
+            }
+        },
         "style-mod": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.0.tgz",
@@ -9885,6 +11187,26 @@
                 "postcss-value-parser": "^4.2.0",
                 "quick-lru": "^5.1.1",
                 "resolve": "^1.22.1"
+            }
+        },
+        "tapable": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+            "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+            "dev": true
+        },
+        "tar": {
+            "version": "6.1.13",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
+            "integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
+            "dev": true,
+            "requires": {
+                "chownr": "^2.0.0",
+                "fs-minipass": "^2.0.0",
+                "minipass": "^4.0.0",
+                "minizlib": "^2.1.1",
+                "mkdirp": "^1.0.3",
+                "yallist": "^4.0.0"
             }
         },
         "terser": {
@@ -9972,15 +11294,200 @@
             "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
             "dev": true
         },
+        "ufo": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
+            "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
+            "dev": true
+        },
+        "unctx": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/unctx/-/unctx-2.1.1.tgz",
+            "integrity": "sha512-RffJlpvLOtolWsn0fxXsuSDfwiWcR6cyuykw2e0+zAggvGW1SesXt9WxIWlWpJhwVCZD/WlxxLqKLS50Q0CkWA==",
+            "dev": true,
+            "requires": {
+                "acorn": "^8.8.1",
+                "estree-walker": "^3.0.1",
+                "magic-string": "^0.26.7",
+                "unplugin": "^1.0.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "8.8.2",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+                    "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+                    "dev": true
+                },
+                "estree-walker": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+                    "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+                    "dev": true,
+                    "requires": {
+                        "@types/estree": "^1.0.0"
+                    }
+                },
+                "magic-string": {
+                    "version": "0.26.7",
+                    "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
+                    "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
+                    "dev": true,
+                    "requires": {
+                        "sourcemap-codec": "^1.4.8"
+                    }
+                }
+            }
+        },
         "undici": {
             "version": "5.10.0",
             "resolved": "https://registry.npmjs.org/undici/-/undici-5.10.0.tgz",
             "integrity": "sha512-c8HsD3IbwmjjbLvoZuRI26TZic+TSEe8FPMLLOkN1AfYRhdjnKBU6yL+IwcSCbdZiX4e5t0lfMDLDCqj4Sq70g=="
         },
+        "unimport": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/unimport/-/unimport-2.2.4.tgz",
+            "integrity": "sha512-qMgmeEGqqrrmEtm0dqxMG37J6xBtrriqxq9hILvDb+e6l2F0yTnJomLoCCp0eghLR7bYGeBsUU5Y0oyiUYhViw==",
+            "dev": true,
+            "requires": {
+                "@rollup/pluginutils": "^5.0.2",
+                "escape-string-regexp": "^5.0.0",
+                "fast-glob": "^3.2.12",
+                "local-pkg": "^0.4.3",
+                "magic-string": "^0.27.0",
+                "mlly": "^1.1.0",
+                "pathe": "^1.1.0",
+                "pkg-types": "^1.0.1",
+                "scule": "^1.0.0",
+                "strip-literal": "^1.0.0",
+                "unplugin": "^1.0.1"
+            },
+            "dependencies": {
+                "escape-string-regexp": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+                    "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+                    "dev": true
+                },
+                "magic-string": {
+                    "version": "0.27.0",
+                    "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+                    "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+                    "dev": true,
+                    "requires": {
+                        "@jridgewell/sourcemap-codec": "^1.4.13"
+                    }
+                }
+            }
+        },
         "universalify": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
             "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+        },
+        "unplugin": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.0.1.tgz",
+            "integrity": "sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==",
+            "dev": true,
+            "requires": {
+                "acorn": "^8.8.1",
+                "chokidar": "^3.5.3",
+                "webpack-sources": "^3.2.3",
+                "webpack-virtual-modules": "^0.5.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "8.8.2",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+                    "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+                    "dev": true
+                }
+            }
+        },
+        "unplugin-auto-import": {
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/unplugin-auto-import/-/unplugin-auto-import-0.13.0.tgz",
+            "integrity": "sha512-nKMxDbkjM4FRPInFfm7sWrJOKgxfKKwb5yLPP+DEGl/SG0/FtBoW1LnZL4PQfx0FXjertoHO1P/5nDf+RSip2Q==",
+            "dev": true,
+            "requires": {
+                "@antfu/utils": "^0.7.2",
+                "@rollup/pluginutils": "^5.0.2",
+                "local-pkg": "^0.4.3",
+                "magic-string": "^0.27.0",
+                "unimport": "^2.1.0",
+                "unplugin": "^1.0.1"
+            },
+            "dependencies": {
+                "magic-string": {
+                    "version": "0.27.0",
+                    "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+                    "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+                    "dev": true,
+                    "requires": {
+                        "@jridgewell/sourcemap-codec": "^1.4.13"
+                    }
+                }
+            }
+        },
+        "unplugin-vue-components": {
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/unplugin-vue-components/-/unplugin-vue-components-0.23.0.tgz",
+            "integrity": "sha512-JAJ+BGvjHvi9P7lICwOzDx2Av+OcI6ZTzvySmjXDNGCNVPrt2NQQmbcp7cW027CR1mRugIX5G//awm3doHyqkg==",
+            "dev": true,
+            "requires": {
+                "@antfu/utils": "^0.7.2",
+                "@nuxt/kit": "^3.1.1",
+                "@rollup/pluginutils": "^5.0.2",
+                "chokidar": "^3.5.3",
+                "debug": "^4.3.4",
+                "fast-glob": "^3.2.12",
+                "local-pkg": "^0.4.3",
+                "magic-string": "^0.27.0",
+                "minimatch": "^6.1.6",
+                "resolve": "^1.22.1",
+                "unplugin": "^1.0.1"
+            },
+            "dependencies": {
+                "brace-expansion": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+                    "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0"
+                    }
+                },
+                "magic-string": {
+                    "version": "0.27.0",
+                    "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+                    "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+                    "dev": true,
+                    "requires": {
+                        "@jridgewell/sourcemap-codec": "^1.4.13"
+                    }
+                },
+                "minimatch": {
+                    "version": "6.1.6",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.1.6.tgz",
+                    "integrity": "sha512-6bR3UIeh/DF8+p6A9Spyuy67ShOq42rOkHWi7eUe3Ua99Zo5lZfGC6lJJWkeoK4k9jQFT3Pl7czhTXimG2XheA==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^2.0.1"
+                    }
+                }
+            }
+        },
+        "untyped": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/untyped/-/untyped-1.2.2.tgz",
+            "integrity": "sha512-EANYd5L6AdpgfldlgMcmvOOnj092nWhy0ybhc7uhEH12ipytDYz89EOegBQKj8qWL3u1wgYnmFjADhsuCJs5Aw==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "^7.20.12",
+                "@babel/standalone": "^7.20.12",
+                "@babel/types": "^7.20.7",
+                "scule": "^1.0.0"
+            }
         },
         "update-browserslist-db": {
             "version": "1.0.9",
@@ -10077,6 +11584,18 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
             "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "webpack-sources": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+            "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+            "dev": true
+        },
+        "webpack-virtual-modules": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz",
+            "integrity": "sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==",
+            "dev": true
         },
         "whatwg-url": {
             "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
         "process": "^0.11.10",
         "regenerator-runtime": "^0.13.11",
         "sass": "^1.57.1",
-        "vite": "^4.1.1"
+        "vite": "^4.1.1",
+        "unplugin-auto-import": "^0.13.0",
+        "unplugin-vue-components": "^0.23.0"
     }
 }

--- a/src/crate-builder/Shell.component.wc.vue
+++ b/src/crate-builder/Shell.component.wc.vue
@@ -9,6 +9,10 @@
             :enable-crate-preview="data.enableCratePreview"
             :enable-browse-entities="data.enableBrowseEntities"
             :enable-template-save="data.enableTemplateSave"
+            @ready="ready"
+            @error="error"
+            @save:crate="saveCrate"
+            @save:crate:template="saveCrateTemplate"
         />
     </div>
 </template>
@@ -49,6 +53,26 @@ function init() {
         enableTemplateSave: $this?.config?.enableTemplateSave ?? false,
         readonly: $this?.config?.readonly ?? false,
     };
+}
+
+// Emit the same events as Shell.component.vue
+const emit = defineEmits(["ready", "error", "save:crate", "save:crate:template"]);
+
+function ready() {
+    emit("ready");
+}
+
+function error(args) {
+    emit("error", args);
+}
+
+function saveCrate(args) {
+    emit("save:crate", args);
+}
+
+function saveCrateTemplate(args) {
+    emit("save:crate:template", args);
+
 }
 </script>
 

--- a/src/crate-builder/Shell.component.wc.vue
+++ b/src/crate-builder/Shell.component.wc.vue
@@ -51,3 +51,14 @@ function init() {
     };
 }
 </script>
+
+<!--
+We import the compiled css from the vue dir, because it is already built.
+For now, font-awesome must be included here and also where the web component is used,
+because for some reason it doesn't load the fonts here, only the css. Loading it again
+in the react component is not an overhead as it will be already cached.
+-->
+<style>
+@import "../../dist/vue/style.css";
+@import url("https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.1/css/all.min.css");
+</style>

--- a/src/crate-builder/index.wc.js
+++ b/src/crate-builder/index.wc.js
@@ -1,21 +1,5 @@
-import { defineCustomElement } from "vue";
+import {defineCustomElement, h} from "vue";
 import DescriboCrateBuilder from "./Shell.component.wc.vue";
-import "./tailwind.css";
-import "@element-plus/theme-chalk/dist/index.css";
-import "./component.css";
-import ElementPlus from "element-plus";
-import "@fortawesome/fontawesome-free/js/all";
-import { config } from "@fortawesome/fontawesome-svg-core";
-config.autoReplaceSvg = "nest";
 
-// The trick is to import from the vue build, because it is built before this, so style.css is already available.
-// If we tried to import from dist/web-component/style.css it was not available since we are in the building process
-// and so style.css wouldbe only available at the end of it.
-import css from "../../dist/vue/style.css";
-
-// Explicitly inline styles in the component
-DescriboCrateBuilder.styles = [css];
-
-// Web Component build entrypoint
 const element = defineCustomElement(DescriboCrateBuilder);
 export default customElements.define("describo-crate-builder", element);

--- a/vite.wc.config.js
+++ b/vite.wc.config.js
@@ -1,7 +1,8 @@
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
-
-const path = require("path");
+import AutoImport from 'unplugin-auto-import/vite'
+import Components from 'unplugin-vue-components/vite'
+import {ElementPlusResolver, ElementUiResolver} from 'unplugin-vue-components/resolvers'
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -15,6 +16,21 @@ export default defineConfig({
         // Don't minify so there's a chance to debug problems while experimenting
         minify: false,
         minifySyntax: false,
+        // rollupOptions: {
+        //     external: "./src/crate-builder/x.js"
+        // }
     },
-    plugins: [vue()],
+    plugins: [
+        vue({
+            // Force inlining styles, especially in Shell.component.wc.vue
+            customElement: true
+        }),
+        // https://element-plus.org/en-US/guide/quickstart.html#on-demand-import
+        AutoImport({
+            resolvers: [ElementPlusResolver()],
+        }),
+        Components({
+            resolvers: [ElementPlusResolver()],
+        }),
+    ],
 });


### PR DESCRIPTION
Fixes use of ElementPlus via ElementPlusResolver and the inlining of generated CSS.

The use of CSS in the web component is still not clear to me. Even though now the generated css is inlined and is (mostly) picked up by the web component some features still don't work.

1. https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.1/css/all.min.css must be imported on the React side as well (annoying, but not really a problem)
2. The AutoComplete component's dropdown is not styled in React unless I do `import "@describo/crate-builder-component/dist/web-component/style.css"`. This should not be needed.

I may have other updates as I proceed with the React wrapper here: https://github.com/dsd-sztaki-hu/crate-builder-component-react

