### PR TITLE
Propagate navigation events + add enableInternalRouting config

### DIFF
--- a/src/crate-builder/Shell.component.wc.vue
+++ b/src/crate-builder/Shell.component.wc.vue
@@ -14,6 +14,7 @@
             @save:crate="saveCrate"
             @save:crate:template="saveCrateTemplate"
             @save:entity:template="saveEntityTemplate"
+            @navigation="navigation"
         />
     </div>
 </template>
@@ -40,6 +41,7 @@ const $emit = defineEmits([
     "save:crate",
     "save:crate:template",
     "save:entity:template",
+    "navigation",
 ]);
 
 let data = reactive(init());
@@ -61,6 +63,7 @@ function init() {
         enableBrowseEntities: $this?.config?.enableBrowseEntities ?? true,
         enableTemplateSave: $this?.config?.enableTemplateSave ?? false,
         readonly: $this?.config?.readonly ?? false,
+        enableInternalRouting: $this?.config?.enableInternalRouting ?? false,
     };
 }
 
@@ -81,5 +84,9 @@ function saveCrateTemplate(args) {
 }
 function saveEntityTemplate(args) {
     $emit("save:entity:template", args);
+}
+
+function navigation(args) {
+    $emit("navigation", args);
 }
 </script>


### PR DESCRIPTION
Just like with other events the new navigation event must be reemitted in [Shell.component.wc.vue](https://github.com/describo/crate-builder-component/compare/master...dsd-sztaki-hu:crate-builder-component:navigation-fix?expand=1#diff-307432f39ffbbe7adff7efd67440b7c63a3cdd917415ed7bc2cd81d773f6c159)

Even with this fix and setting `enableInternalRouting` I don't seem to receive navigation events because here it won't reach event emitting because we don't have $route in the web component:

https://github.com/describo/crate-builder-component/blob/0c26c555fc542bd9c368cc0bd7bd479f4b33493b/src/crate-builder/Shell.component.vue#L193
