### PR TITLE
Direct entity editing

### DIFF
--- a/src/crate-builder/Shell.component.vue
+++ b/src/crate-builder/Shell.component.vue
@@ -37,6 +37,9 @@ const props = defineProps({
     profile: {
         type: [Object, undefined],
     },
+    entityId: {
+        type: [String, undefined]
+    },
     mode: {
         type: [String, undefined],
         default: "embedded",
@@ -91,7 +94,7 @@ const data = reactive({
     crateManager: {},
 });
 
-watch([() => props.crate, () => props.profile], () => {
+watch([() => props.crate, () => props.profile, () => props.entityId], () => {
     data.ready = false;
     data.debouncedInit();
 });
@@ -102,6 +105,11 @@ watch(
             data.debouncedSetCurrentEntity({ describoId: $route?.query?.id });
     }
 );
+
+// if new entity is selected it sets it as current entity
+watch([() => props.entityId], () => {
+    data.debouncedSetCurrentEntity({id: props.entityId})
+});
 onBeforeMount(() => {
     $router?.replace({ query: "" });
     data.configuration = reactive(configure());
@@ -141,7 +149,14 @@ function init() {
         return;
     }
 
-    setCurrentEntity({ name: "RootDataset" });
+    if (props.entityId) {
+        console.log("### entity id is present", props.entityId)
+        setCurrentEntity({id: props.entityId})
+    } else {
+        console.log("### entity id is NOT present", props.entityId)
+        setCurrentEntity({ name: "RootDataset" });
+    }
+    
     ready();
 }
 function configure() {

--- a/src/crate-builder/Shell.component.wc.vue
+++ b/src/crate-builder/Shell.component.wc.vue
@@ -4,6 +4,7 @@
             :crate="data.crate"
             :profile="data.profile"
             :lookup="data.lookup"
+            :entityId="data.entityId"
             :readonly="data.readonly"
             :enable-context-editor="data.enableContextEditor"
             :enable-crate-preview="data.enableCratePreview"

--- a/src/crate-builder/Shell.component.wc.vue
+++ b/src/crate-builder/Shell.component.wc.vue
@@ -59,6 +59,7 @@ function init() {
         crate: $this.crate,
         profile: $this.profile,
         lookup: $this.lookup,
+        entityId: $this.entityId,
         enableContextEditor: $this?.config?.enableContextEditor ?? true,
         enableCratePreview: $this?.config?.enableCratePreview ?? true,
         enableBrowseEntities: $this?.config?.enableBrowseEntities ?? true,


### PR DESCRIPTION
This feature allows targeting the editing of a specific entity instead of starting the crate builder at the RootDataset.

It introduces the new property `entityId`, which if set will cause the crate builder to show the editor for the entity with the specified ID. If the `entityId` is not set then the default behaviour is applied and the crate builder starts with the RootDataset.