### PR TITLE
Disable generation of process.env in web component build

### DIFF
--- a/vite.wc.config.cjs
+++ b/vite.wc.config.cjs
@@ -30,4 +30,8 @@ export default defineConfig({
             resolvers: [ElementPlusResolver()],
         }),
     ],
+    define: {
+        // No process.env in web component
+        'process.env': {}
+    }
 });


### PR DESCRIPTION
Without this, in pure HTML the web component fails with:

Uncaught ReferenceError: process is not defined