### PR TITLE
Workaround for strange autocomplete behavior in WC/react

### DIFF
--- a/src/crate-builder/RenderEntity/AutoComplete.component.vue
+++ b/src/crate-builder/RenderEntity/AutoComplete.component.vue
@@ -69,7 +69,10 @@ const data = reactive({
     promiseTimeout: 2500,
     selection: undefined,
     loading: false,
-    debouncedQuerySearch: debounce(querySearch, 500),
+    debouncedQuerySearch: (queryString) => {
+        data.selection = queryString;
+        debounce(() => querySearch(queryString), 500)();
+    },
     matches: [],
     entities: [],
 });


### PR DESCRIPTION
When using the web component build of the create builder the autocomplete behaves strange as reported in #39. I found that the selection (the user typed text) is reset to its default value (undefined) for unknown reason.

While I don't know the exact root of the problem I found that if we make sure `data.selection` is in sync with the query string then it works in Vue as usual and also fixes the WC/react issues.

The data.selection is set in debouncedQuerySearch and not in querySearch because of the debounce the user may type some more chars while the search starts with the older query string and this causes some jittering in the input field.