### PR TITLE
Keep current tab when profile changes with compatible layout

### DIFF
--- a/src/crate-builder/RenderEntity/Shell.component.vue
+++ b/src/crate-builder/RenderEntity/Shell.component.vue
@@ -299,7 +299,18 @@ onMounted(() => {
         () => {
             initProfile();
             data.extraProperties = [];
-            data.activeTab = "about";
+            // If we always reset to "about" ...
+            if (props.configuration.resetTabOnEntityChange) {
+                data.activeTab = "about";
+            }
+            // ... otherwise only change to "about" if the newly set profile doesn't have a layout with the same name as
+            // the currently selected one. If there is such layout, keep that (no change to data.activeTab).
+            else {
+                const layouts = data.profileManager.getLayouts({entity: props.entity});
+                if (layouts == null || !layouts[data.activeTab]) {
+                    data.activeTab = "about"
+                }
+            }
             const entity = props.crateManager.getEntity({ id: props.entity["@id"] });
             init({ entity });
         }


### PR DESCRIPTION
This is a suggestion for a small enhancement that is similar to how such change is handled for entities and keeping the current tab if `resetTabOnEntityChange==false`. In my app we change the profile frequently and would be great to keep the current selected between profile changes.

When the profile changes, previously we automatically reset the tab to "about" uncoditionally. 

In this implementation we change to "about" if `resetTabOnEntityChange==true` or if the new profile doesn't have a layout matching the currently selected one. In this case we fall back to "about".

Here I used `resetTabOnEntityChange` but maybe we should introduce a `resetTabOnProfileChange` or have just one such flag to control any tab changes, eg. `resetTabOnChange`