### PR TITLE
Add semantic css classes to properties

### DIFF
--- a/src/crate-builder/RenderEntity/Add.component.vue
+++ b/src/crate-builder/RenderEntity/Add.component.vue
@@ -81,7 +81,7 @@
                 @link:entity="linkEntity"
             />
         </div>
-        <div v-else class="p-1 w-full">
+        <div v-else class="p-1 w-full describo-property-type-entity">
             <div
                 class="flex flex-row space-x-2 divide-y divide-gray-300 text-gray-600"
                 v-if="data.addType"

--- a/src/crate-builder/RenderEntity/DisplayPropertyName.component.vue
+++ b/src/crate-builder/RenderEntity/DisplayPropertyName.component.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>{{ labelDisplay }}</div>
+    <div class="describo-property-name">{{ labelDisplay }}</div>
 </template>
 
 <script setup>

--- a/src/crate-builder/RenderEntity/RenderEntityId.component.vue
+++ b/src/crate-builder/RenderEntity/RenderEntityId.component.vue
@@ -1,8 +1,8 @@
 <template>
     <div class="flex flex-row">
-        <div class="w-1/3 xl:w-1/5 flex flex-col">@id</div>
+        <div class="w-1/3 xl:w-1/5 flex flex-col describo-property-name">@id</div>
 
-        <div class="w-2/3 xl:w-4/5 flex flex-row" v-if="!configuration.readonly">
+        <div class="w-2/3 xl:w-4/5 flex flex-row describo-property-value" v-if="!configuration.readonly">
             <div
                 v-if="
                     props.entity['@id'] === './' ||
@@ -22,7 +22,7 @@
                 />
             </div>
         </div>
-        <div class="w-2/3 xl:w-4/5 flex flex-row" v-else>
+        <div class="w-2/3 xl:w-4/5 flex flex-row describo-property-value" v-else>
             <div v-if="isURL(props.entity['@id'])">
                 <a class="text-blue-800" :href="props.entity['@id']" target="_blank">{{
                     props.entity["@id"]

--- a/src/crate-builder/RenderEntity/RenderEntityName.component.vue
+++ b/src/crate-builder/RenderEntity/RenderEntityName.component.vue
@@ -1,8 +1,8 @@
 <template>
     <div class="flex flex-row">
         <div class="w-1/3 xl:w-1/5 flex flex-col">
-            <div>{{ $t("name_field_label") }}</div>
-            <div class="text-gray-600 font-light text-xs pr-1">
+            <div class="describo-property-name">{{ $t("name_field_label") }}</div>
+            <div class="text-gray-600 font-light text-xs pr-1 describo-property-help">
                 {{ $t("name_field_help") }}
             </div>
         </div>

--- a/src/crate-builder/RenderEntity/RenderEntityProperty.component.vue
+++ b/src/crate-builder/RenderEntity/RenderEntityProperty.component.vue
@@ -1,9 +1,9 @@
 <template>
     <div
         class="flex flex-row flex-grow p-2 describo-property-background"
-        :class="{ 'bg-red-200': props.highlightRequired && isRequired && !isValid }"
+        :class="[{ 'bg-red-200': props.highlightRequired && isRequired && !isValid }, `describo-property describo-property-name-${props.property}`]"
     >
-        <div class="w-1/3 xl:w-1/5 flex flex-col">
+        <div class="w-1/3 xl:w-1/5 flex flex-col describo-property-heading">
             <div>
                 <display-property-name-component
                     :property="props.property"
@@ -22,11 +22,11 @@
                 ({{ $t("not_defined_in_profile") }})
             </div>
         </div>
-        <div class="w-2/3 xl:w-4/5 flex flex-col flex-grow">
+        <div class="w-2/3 xl:w-4/5 flex flex-col flex-grow describo-property-value">
             <!-- render all of the simple things (text, textarea, date etc) in a column -->
             <div class="flex flex-col space-y-1" v-if="data.simpleInstances.length">
                 <div v-for="instance of data.simpleInstances" :key="instance.idx">
-                    <div v-if="propertyDefinition.readonly">
+                    <div v-if="propertyDefinition.readonly" class="describo-property-value-readonly">
                         {{ instance.value }}
                     </div>
                     <div v-else class="flex flex-row space-x-2">

--- a/src/crate-builder/RenderEntity/RenderEntityType.component.vue
+++ b/src/crate-builder/RenderEntity/RenderEntityType.component.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="flex flex-row">
-        <div class="w-1/3 xl:w-1/5 flex flex-col">@type</div>
+        <div class="w-1/3 xl:w-1/5 flex flex-col describo-property-name">@type</div>
         <div class="w-2/3 xl:w-4/5 flex flex-row flex-wrap">
             <div v-for="etype of types" :key="etype" class="m-1">
                 <el-tag size="large" :closable="closable" @close="deleteType(etype)">{{

--- a/src/crate-builder/RenderEntity/RenderPropertyHelp.component.vue
+++ b/src/crate-builder/RenderEntity/RenderPropertyHelp.component.vue
@@ -1,12 +1,12 @@
 <template>
     <div>
-        <div class="text-gray-600 font-light text-sm pr-1" v-if="!showToggle">
+        <div class="text-gray-600 font-light text-sm pr-1 describo-property-help" v-if="!showToggle">
             {{ help }}
         </div>
 
         <div
             v-if="showToggle"
-            class="text-gray-600 font-light text-sm pr-1 cursor-pointer"
+            class="text-gray-600 font-light text-sm pr-1 cursor-pointer describo-property-help-more"
             @click="data.showMore = !data.showMore"
         >
             {{ help }} <span v-if="!data.showMore">...</span>

--- a/src/crate-builder/RenderEntity/Shell.component.vue
+++ b/src/crate-builder/RenderEntity/Shell.component.vue
@@ -20,7 +20,7 @@
                 <!-- render entity id -->
                 <div class="flex flex-row space-x-2 my-2 p-2">
                     <render-entity-id-component
-                        class="flex-grow"
+                        class="flex-grow describo-property describo-property-name-id"
                         :class="{
                             'bg-green-200 rounded p-1 my-1': data.savedProperty === '@id',
                         }"
@@ -42,7 +42,7 @@
 
                 <!-- render entity type -->
                 <render-entity-type-component
-                    class="my-2 p-2"
+                    class="my-2 p-2 describo-property describo-property-name-type"
                     :crate-manager="crateManager"
                     :entity="contextEntity"
                     @update:entity="updateEntity"
@@ -50,7 +50,7 @@
 
                 <!-- render entity name -->
                 <render-entity-name-component
-                    class="my-2 p-2"
+                    class="my-2 p-2 describo-property describo-property-name-name"
                     :class="{
                         'bg-green-200 rounded p-1 my-1': data.savedProperty === 'name',
                     }"
@@ -155,7 +155,7 @@
                         </div>
                         <div v-if="tab.name === 'about'">
                             <render-entity-id-component
-                                class="my-2 p-2"
+                                class="my-2 p-2 describo-property describo-property-name-id"
                                 :class="{
                                     'bg-green-200 rounded p-1 my-1': data.savedProperty === '@id',
                                 }"
@@ -163,13 +163,13 @@
                                 @update:entity="updateEntity"
                             />
                             <render-entity-type-component
-                                class="my-2 p-2"
+                                class="my-2 p-2 describo-property describo-property-name-type"
                                 :crate-manager="crateManager"
                                 :entity="contextEntity"
                                 @update:entity="updateEntity"
                             />
                             <render-entity-name-component
-                                class="my-2 p-2"
+                                class="my-2 p-2 describo-property describo-property-name-name"
                                 :class="{
                                     'bg-green-200 rounded p-1 my-1': data.savedProperty === 'name',
                                 }"

--- a/src/crate-builder/primitives/Date.component.vue
+++ b/src/crate-builder/primitives/Date.component.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="flex flex-col">
+    <div class="flex flex-col describo-property-type-date">
         <el-date-picker
             v-model="data.internalValue"
             type="date"

--- a/src/crate-builder/primitives/DateTime.component.vue
+++ b/src/crate-builder/primitives/DateTime.component.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="flex flex-col">
+    <div class="flex flex-col describo-property-type-datetime">
         <el-date-picker
             v-model="data.internalValue"
             type="datetime"

--- a/src/crate-builder/primitives/Geo.component.vue
+++ b/src/crate-builder/primitives/Geo.component.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="flex flex-row text-gray-600">
+    <div class="flex flex-row text-gray-600 describo-property-type-geo">
         <div
             class="flex flex-col p-4"
             :class="{

--- a/src/crate-builder/primitives/Map.component.vue
+++ b/src/crate-builder/primitives/Map.component.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :id="mapId" class="map-style"></div>
+    <div :id="mapId" class="map-style describo-property-type-map"></div>
 </template>
 
 <script setup>

--- a/src/crate-builder/primitives/Number.component.vue
+++ b/src/crate-builder/primitives/Number.component.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="flex flex-col">
+    <div class="flex flex-col describo-property-type-number">
         <el-input
             class="w-full"
             type="number"

--- a/src/crate-builder/primitives/Select.component.vue
+++ b/src/crate-builder/primitives/Select.component.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="flex flex-col">
+    <div class="flex flex-col describo-property-type-select">
         <el-select
             v-if="data.hasValidValues"
             class="w-full"

--- a/src/crate-builder/primitives/Text.component.vue
+++ b/src/crate-builder/primitives/Text.component.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="flex flex-col space-y-2">
+    <div class="flex flex-col space-y-2 describo-property-type-text">
         <div class="flex flex-row space-x-2">
             <el-input
                 class="w-full"

--- a/src/crate-builder/primitives/Time.component.vue
+++ b/src/crate-builder/primitives/Time.component.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="flex flex-col">
+    <div class="flex flex-col describo-property-type-time">
         <el-input
             class="w-full"
             type="text"

--- a/src/crate-builder/primitives/Url.component.vue
+++ b/src/crate-builder/primitives/Url.component.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="flex flex-col">
+    <div class="flex flex-col describo-property-type-url">
         <div class="flex flex-row flex-grow space-x-2">
             <el-input
                 class="w-full"

--- a/src/crate-builder/primitives/Value.component.vue
+++ b/src/crate-builder/primitives/Value.component.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="flex flex-col">
+    <div class="flex flex-col describo-property-type-value">
         <div v-if="isValidString">{{ props.value }}</div>
         <div v-if="!isValidString">
             {{ $t('invalid_value_value', {type: props.value}) }}


### PR DESCRIPTION
This is an experiment/proof of concept implementation to add semantic css classes to make it easier to find and style rocrate property components together or selectively. 

This feature would allow users of Describo to make overall or precise styling modifications as necessary. Without this it is difficult or sometimes not even possible to style selected properties from CSS.

It generates the following css classes into components (indentation reflects their use inside a property component):

```
describo-property: row of a property
describo-property-name-<name of property>: unique class for the propery by its name
	describo-property-heading: left column with name and help
		describo-property-name: element containing the property name
		describo-property-help: element containing the property's help
		describo-property-help-more: element containing the property's help with a "show more" option
	describo-property-value: the right column with the property's value (component)
		describo-property-type-<type name>: the type of the property's value, eg. describo-property-type-date, describo-property-type-url, etc.
```

All this allows styling components like this. Some styles applied to all components, some selectively to one kind of property:

![screenshot-localhost_9000-2023 11 21-13_58_46](https://github.com/describo/crate-builder-component/assets/1926265/2f42664e-379c-4562-ad6d-943c656c8c9c)

Looking forward to hearing what you think about this!