### PR TITLE
Add save button for number type fields

### DIFF
--- a/src/crate-builder/primitives/Number.component.vue
+++ b/src/crate-builder/primitives/Number.component.vue
@@ -1,6 +1,12 @@
 <template>
     <div class="flex flex-col describo-property-type-number">
-        <el-input class="w-full" type="number" @change="save" v-model="data.internalValue" resize="vertical"></el-input>
+        <div class="flex flex-row space-x-2">
+            <el-input class="w-full" type="number" @change="debouncedSave" v-model="data.internalValue"
+                resize="vertical"></el-input>
+            <el-button @click="save" type="success" size="default" :disabled="!isValidNumber">
+                <i class="fas fa-check fa-fw"></i>
+            </el-button>
+        </div>
         <div class="text-xs text-gray-700" v-if="!isValidNumber">
             {{ $t("invalid_number_value", { value: data.internalValue }) }}
         </div>
@@ -11,10 +17,13 @@
 </template>
 
 <script setup>
-import { ElInput } from "element-plus";
+import { ElInput, ElButton } from "element-plus";
 import { reactive, watch, computed } from "vue";
 import isNumeric from "validator/es/lib/isNumeric";
+import debounce from "lodash-es/debounce.js";
 import { $t } from "../i18n";
+
+const debouncedSave = debounce(save, 200);
 
 const props = defineProps({
     property: {
@@ -73,27 +82,27 @@ function validateNumberConstraints(value) {
         data.constraints.maxValue < value
     ) return false;
     if (
-        data.constraints.numberType && 
+        data.constraints.numberType &&
         !isNumberType(value, data.constraints.numberType)
     ) return false;
     return true;
 }
 
 function isNumberType(value, numberTypes) {
-  const stringValue = String(value).toLowerCase();
+    const stringValue = String(value).toLowerCase();
 
-  const typeMap = {
-    'any': true,
-    'long': Number.isSafeInteger(value),
-    'int': Number.isInteger(value),
-    'float': stringValue.includes('.') && !Number.isNaN(parseFloat(value)),
-    'double': !Number.isNaN(parseFloat(value))
-  };
+    const typeMap = {
+        'any': true,
+        'long': Number.isSafeInteger(value),
+        'int': Number.isInteger(value),
+        'float': stringValue.includes('.') && !Number.isNaN(parseFloat(value)),
+        'double': !Number.isNaN(parseFloat(value))
+    };
 
-  return (
-    Array.isArray(numberTypes) &&
-    numberTypes.some(type => typeMap[type.toLowerCase()])
-  );
+    return (
+        Array.isArray(numberTypes) &&
+        numberTypes.some(type => typeMap[type.toLowerCase()])
+    );
 }
 
 function getConstraintsString() {


### PR DESCRIPTION
I added a save button for number type fields to achieve a unified look. 

<img width="409" alt="image" src="https://github.com/describo/crate-builder-component/assets/61116319/c4524d07-5a0e-434e-8ae6-6fa1e6a897f6">

<img width="421" alt="image" src="https://github.com/describo/crate-builder-component/assets/61116319/07c2b7d4-b790-4152-899a-cfcbc113c06e">


