### PR TITLE
Saving number-type values as actual numeric values 

### DIFF
--- a/src/crate-builder/primitives/Number.component.vue
+++ b/src/crate-builder/primitives/Number.component.vue
@@ -62,7 +62,7 @@ function save() {
     if (data.isValidNumber && isValidNumberConstraints.value) {
         $emit("save:property", {
             property: props.property,
-            value: data.internalValue,
+            value: Number(data.internalValue),
         });
     }
 }


### PR DESCRIPTION
I noticed that when adding a new number-type value, it was stored as a string in the crate. In my opinion, it would be better to store numbers as numbers for clearer and more efficient data handling.