### PR TITLE
Prevent switching from text type to url

### DIFF
--- a/src/app/EmbeddedComponent.component.vue
+++ b/src/app/EmbeddedComponent.component.vue
@@ -45,6 +45,7 @@
                 :enable-internal-routing="true"
                 :enable-reverse-link-browser="data.configuration.enableReverseLinkBrowser"
                 :purge-unlinked-entities="data.configuration.purgeUnlinkedEntities"
+                :enable-url-markup="data.configuration.enableUrlMarkup"
                 :web-component="false"
                 :language="data.configuration.language"
                 :tab-location="data.configuration.tabLocation"
@@ -173,6 +174,7 @@ const data = reactive({
         enableBrowseEntities: true,
         enableTemplateSave: true,
         enableReverseLinkBrowser: true,
+        enableUrlMarkup: true,
         purgeUnlinkedEntities: true,
         readonly: false,
         language: "en",

--- a/src/crate-builder/RenderEntity/RenderEntityPropertyInstance.component.vue
+++ b/src/crate-builder/RenderEntity/RenderEntityPropertyInstance.component.vue
@@ -177,7 +177,7 @@ function isSelect() {
     return props?.definition?.values?.includes(props.value) ? true : false;
 }
 function isUrl(string) {
-    let result = isURL(string) && props.property === 'url';
+    let result = isURL(string) && configuration.value.enableUrlMarkup;
     return result;
 }
 function isBoolean() {

--- a/src/crate-builder/RenderEntity/RenderEntityPropertyInstance.component.vue
+++ b/src/crate-builder/RenderEntity/RenderEntityPropertyInstance.component.vue
@@ -177,7 +177,7 @@ function isSelect() {
     return props?.definition?.values?.includes(props.value) ? true : false;
 }
 function isUrl(string) {
-    let result = isURL(string);
+    let result = isURL(string) && props.property === 'url';
     return result;
 }
 function isBoolean() {

--- a/src/crate-builder/RenderEntity/Shell.component.vue
+++ b/src/crate-builder/RenderEntity/Shell.component.vue
@@ -538,18 +538,18 @@ function createProperty(patch) {
         id: contextEntity.value["@id"],
         ...patch,
     });
-    if (isURL(patch.value)) {
-        createEntity({
-            property: patch.property,
-            json: {
-                "@id": patch.value,
-                "@type": "URL",
-                name: patch.value,
-            },
-        });
-    } else {
+    // if (isURL(patch.value)) {
+    //     createEntity({
+    //         property: patch.property,
+    //         json: {
+    //             "@id": patch.value,
+    //             "@type": "URL",
+    //             name: patch.value,
+    //         },
+    //     });
+    // } else {
         cm.value.setProperty({ id: contextEntity.value["@id"], ...patch });
-    }
+    // }
     refresh();
     saveCrate();
     notifySave(patch.property);

--- a/src/crate-builder/RenderEntity/Shell.component.vue
+++ b/src/crate-builder/RenderEntity/Shell.component.vue
@@ -538,18 +538,18 @@ function createProperty(patch) {
         id: contextEntity.value["@id"],
         ...patch,
     });
-    // if (isURL(patch.value)) {
-    //     createEntity({
-    //         property: patch.property,
-    //         json: {
-    //             "@id": patch.value,
-    //             "@type": "URL",
-    //             name: patch.value,
-    //         },
-    //     });
-    // } else {
+    if (isURL(patch.value) && configuration.value.enableUrlMarkup) {
+        createEntity({
+            property: patch.property,
+            json: {
+                "@id": patch.value,
+                "@type": "URL",
+                name: patch.value,
+            },
+        });
+    } else {
         cm.value.setProperty({ id: contextEntity.value["@id"], ...patch });
-    // }
+    }
     refresh();
     saveCrate();
     notifySave(patch.property);

--- a/src/crate-builder/Shell.component.vue
+++ b/src/crate-builder/Shell.component.vue
@@ -135,6 +135,11 @@ const props = defineProps({
         type: String,
         default: "en",
     },
+    enableUrlMarkup: {
+        type: Boolean,
+        default: true,
+        validator: (val) => [true, false].includes(val),
+    }
 });
 
 const $emit = defineEmits([
@@ -244,6 +249,7 @@ onMounted(async () => {
                 () => props.enableBrowseEntities,
                 () => props.enableTemplateSave,
                 () => props.enableReverseLinkBrowser,
+                () => props.enableUrlMarkup,
                 () => props.purgeUnlinkedEntities,
                 () => props.readonly,
                 () => props.language,
@@ -322,6 +328,7 @@ function configure() {
         enableBrowseEntities: props.enableBrowseEntities,
         enableTemplateSave: props.enableTemplateSave,
         enableReverseLinkBrowser: props.enableReverseLinkBrowser,
+        enableUrlMarkup: props.enableUrlMarkup,
         readonly: props.readonly,
         webComponent: props.webComponent,
         purgeUnlinkedEntities: props.purgeUnlinkedEntities,


### PR DESCRIPTION
I have encountered a problem where, in my Describo profile, I define a field with a Text type. However, if I save a URL as its value, it switches the type to URL and saves an object instead of a string. In my opinion, since Describo can handle both Text and URL types, it could be more consistent if the fields would maintain the type originally assigned to them in the profile.

In this PR, I removed the code that caused the type switching. If this feature is necessary in Describo, do you have any ideas for a better solution?