### PR TITLE
Custom placeholder texts

### DIFF
--- a/src/crate-builder/RenderEntity/Add.component.vue
+++ b/src/crate-builder/RenderEntity/Add.component.vue
@@ -22,7 +22,7 @@
                 type="text"
                 :definition="props.definition"
                 @save:property="createProperty"
-                :placeholder="$t('add_text')"
+                :placeholder="props.placeholder || $t('add_text')"
             />
             <text-component
                 v-if="data.addType === 'TextArea'"
@@ -30,6 +30,7 @@
                 type="textarea"
                 :definition="props.definition"
                 @save:property="createProperty"
+                :placeholder="props.placeholder"
             />
             <date-component
                 v-if="data.addType === 'Date'"
@@ -153,6 +154,10 @@ const props = defineProps({
         type: Boolean,
         default: false,
     },
+    placeholder: {
+        type: String,
+        required: false,
+    }
 });
 const $emit = defineEmits(["create:property", "create:entity", "link:entity"]);
 

--- a/src/crate-builder/RenderEntity/RenderEntityProperty.component.vue
+++ b/src/crate-builder/RenderEntity/RenderEntityProperty.component.vue
@@ -74,6 +74,7 @@
                 :property="props.property"
                 :definition="propertyDefinition"
                 :embedded="false"
+                :placeholder="propertyDefinition.placeholder"
                 @create:property="createProperty"
                 @create:entity="createEntity"
                 @link:entity="linkEntity"

--- a/src/crate-builder/RenderEntity/RenderEntityPropertyInstance.component.vue
+++ b/src/crate-builder/RenderEntity/RenderEntityPropertyInstance.component.vue
@@ -63,6 +63,7 @@
                 :property="props.property"
                 :value="props.value"
                 :definition="props.definition"
+                :placeholder="props.placeholder"
                 @save:property="savePropertyValue"
             />
             <text-component
@@ -70,6 +71,7 @@
                 :property="props.property"
                 :value="props.value"
                 :definition="props.definition"
+                :placeholder="props.placeholder"
                 @save:property="savePropertyValue"
             />
         </div>

--- a/src/examples/profile/profile-with-constraints.json
+++ b/src/examples/profile/profile-with-constraints.json
@@ -17,7 +17,8 @@
                     "help": "Text field with no constraint",
                     "required": false,
                     "multiple": true,
-                    "type": ["Text"]
+                    "type": ["Text"],
+                    "placeholder": "Enter text here"
                 },
                 {
                     "id": "https://schema.org/text1",


### PR DESCRIPTION
Hi Marco,

This is our proposal to extend the input descriptor of Profiles with a `placeholder` field, so that one can define custom, more semantic prompt in place of the default `Add text`.

See the `profile-with-constraints.json` Profile and its `Text field with no constraint` as an example in the develop app.

It is backward compatible and requires minimal code change. What do you think?
